### PR TITLE
JL - Weekly Tasks Due Chart

### DIFF
--- a/frontend/src/components/Calendar/Sidebar.css
+++ b/frontend/src/components/Calendar/Sidebar.css
@@ -1,3 +1,10 @@
+.sidebar h4 {
+    color: var(--faint-text);
+    font-size: 1.3rem;
+    font-weight: 400;
+    text-align: center;
+}
+
 .sidebar h2 {
     color: var(--faint-text);
     font-size: 1.3rem;

--- a/frontend/src/components/Calendar/Sidebar.css
+++ b/frontend/src/components/Calendar/Sidebar.css
@@ -1,7 +1,5 @@
-.sidebar h4 {
-    color: var(--faint-text);
-    font-size: 1.3rem;
-    font-weight: 400;
+.sidebar p {
+    color: var(--accent-background);
     text-align: center;
 }
 

--- a/frontend/src/components/Calendar/Sidebar.js
+++ b/frontend/src/components/Calendar/Sidebar.js
@@ -1,11 +1,13 @@
 import React from "react";
 import "./Sidebar.css";
+import TaskCalendarChart from "../ToDo/TaskCalendarChart.js";
 
 const Sidebar = () => {
     return (
       <div className="sidebar">
         <h2>Your Events</h2>
         <h2>Upcoming Deadlines</h2>
+        <TaskCalendarChart />
         <h2>Recommendations by timewise</h2>
       </div>
     );

--- a/frontend/src/components/ToDo/TaskCalendarChart.js
+++ b/frontend/src/components/ToDo/TaskCalendarChart.js
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from "react";
+import { Bar } from "react-chartjs-2";
+import "chart.js/auto";
+
+const TaskCalendarChart = () => {
+  const [tasks, setTasks] = useState([]);
+
+  useEffect(() => {
+    const storedTasks = JSON.parse(localStorage.getItem("tasks")) || [];
+    setTasks(storedTasks);
+  }, []);
+
+  // Get today's date
+  const today = new Date();
+  const startOfWeek = new Date(today);
+  startOfWeek.setDate(today.getDate() - today.getDay()); // Start from Sunday
+
+  // Create an array for each day of the week
+  const daysOfWeek = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const tasksPerDay = new Array(7).fill(0); // Array to store task counts per day
+
+  // **Filter only tasks that are not completed**
+  const pendingTasks = tasks.filter((task) => task.status !== "Done");
+
+  // Count pending tasks for each day of the current week
+  pendingTasks.forEach((task) => {
+    const taskDate = new Date(task.deadline);
+    const dayIndex = taskDate.getDay(); // Get index (0 = Sunday, 6 = Saturday)
+    
+    if (taskDate >= startOfWeek && taskDate < new Date(startOfWeek).setDate(startOfWeek.getDate() + 7)) {
+      tasksPerDay[dayIndex]++;
+    }
+  });
+
+  // Chart Data
+  const data = {
+    labels: daysOfWeek, // Days of the week on x-axis
+    datasets: [
+      {
+        label: "In Progress Tasks",
+        data: tasksPerDay,
+        backgroundColor: "#ffcc00", // Yellow to indicate pending tasks
+        borderColor: "#ffcc00",
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const options = {
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          stepSize: 1, // Adjust step size dynamically
+        },
+      },
+    },
+  };
+
+  return (
+    <div>
+      <h4>Due This Week</h4>
+      <div style={{ backgroundColor: "#fff", padding: "10px", borderRadius: "10px" }}>
+        <Bar data={data} options={options} />
+    </div>
+    </div>
+  );
+};
+
+export default TaskCalendarChart;

--- a/frontend/src/components/ToDo/TaskCalendarChart.js
+++ b/frontend/src/components/ToDo/TaskCalendarChart.js
@@ -1,23 +1,49 @@
 import React, { useState, useEffect } from "react";
 import { Bar } from "react-chartjs-2";
 import "chart.js/auto";
+import { db, auth } from "../../firebase";
+import { collection, getDocs } from "firebase/firestore";
+import { onAuthStateChanged } from "firebase/auth";
 
-const TaskCalendarChart = () => {
+const TasksDueChart = () => {
   const [tasks, setTasks] = useState([]);
+  const [user, setUser] = useState(null); // Track authentication state
 
   useEffect(() => {
-    const storedTasks = JSON.parse(localStorage.getItem("tasks")) || [];
-    setTasks(storedTasks);
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser);
+      if (currentUser) {
+        fetchTasks(currentUser.uid);
+      } else {
+        setTasks([]); // Clear tasks if user logs out
+      }
+    });
+
+    return () => unsubscribe();
   }, []);
+
+  // Fetch tasks from Firestore
+  const fetchTasks = async (uid) => {
+    try {
+      const querySnapshot = await getDocs(collection(db, `users/${uid}/tasks`));
+      const tasksData = querySnapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      }));
+      setTasks(tasksData);
+    } catch (error) {
+      console.error("Error fetching tasks:", error);
+    }
+  };
 
   // Get today's date
   const today = new Date();
   const startOfWeek = new Date(today);
-  startOfWeek.setDate(today.getDate() - today.getDay()); // Start from Sunday
+  startOfWeek.setDate(today.getDate() - today.getDay());
 
-  // Create an array for each day of the week
+  
   const daysOfWeek = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const tasksPerDay = new Array(7).fill(0); // Array to store task counts per day
+  const tasksPerDay = new Array(7).fill(0); 
 
   // **Filter only tasks that are not completed**
   const pendingTasks = tasks.filter((task) => task.status !== "Done");
@@ -25,7 +51,7 @@ const TaskCalendarChart = () => {
   // Count pending tasks for each day of the current week
   pendingTasks.forEach((task) => {
     const taskDate = new Date(task.deadline);
-    const dayIndex = taskDate.getDay(); // Get index (0 = Sunday, 6 = Saturday)
+    const dayIndex = taskDate.getDay(); 
     
     if (taskDate >= startOfWeek && taskDate < new Date(startOfWeek).setDate(startOfWeek.getDate() + 7)) {
       tasksPerDay[dayIndex]++;
@@ -34,10 +60,10 @@ const TaskCalendarChart = () => {
 
   // Chart Data
   const data = {
-    labels: daysOfWeek, // Days of the week on x-axis
+    labels: daysOfWeek,
     datasets: [
       {
-        label: "In Progress Tasks",
+        label: "Pending Tasks",
         data: tasksPerDay,
         backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--in-progress-color').trim(), // Yellow to indicate pending tasks
         borderColor: getComputedStyle(document.documentElement).getPropertyValue('--in-progress-color').trim(),
@@ -57,14 +83,19 @@ const TaskCalendarChart = () => {
     },
   };
 
+  // **Render nothing if user is not signed in**
+  if (!user) {
+    return <p>Please sign in to view your tasks chart.</p>;
+  }
+
   return (
     <div>
-      <h4>Due This Week</h4>
+      <p>Tasks Remaining This Week</p>
       <div style={{ backgroundColor: "#fff", padding: "10px", borderRadius: "10px" }}>
-        <Bar data={data} options={options} />
-    </div>
+      <Bar data={data} options={options} />
+      </div>
     </div>
   );
 };
 
-export default TaskCalendarChart;
+export default TasksDueChart;

--- a/frontend/src/components/ToDo/TaskCalendarChart.js
+++ b/frontend/src/components/ToDo/TaskCalendarChart.js
@@ -39,8 +39,8 @@ const TaskCalendarChart = () => {
       {
         label: "In Progress Tasks",
         data: tasksPerDay,
-        backgroundColor: "#ffcc00", // Yellow to indicate pending tasks
-        borderColor: "#ffcc00",
+        backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--in-progress-color').trim(), // Yellow to indicate pending tasks
+        borderColor: getComputedStyle(document.documentElement).getPropertyValue('--in-progress-color').trim(),
         borderWidth: 1,
       },
     ],

--- a/frontend/src/components/ToDo/TaskCalendarChart.js
+++ b/frontend/src/components/ToDo/TaskCalendarChart.js
@@ -5,7 +5,7 @@ import { db, auth } from "../../firebase";
 import { collection, getDocs } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
 
-const TasksDueChart = () => {
+const TasksCalendarChart = () => {
   const [tasks, setTasks] = useState([]);
   const [user, setUser] = useState(null); // Track authentication state
 
@@ -98,4 +98,4 @@ const TasksDueChart = () => {
   );
 };
 
-export default TasksDueChart;
+export default TasksCalendarChart;


### PR DESCRIPTION
I implemented a weekly chart that displays user's tasks that are due for the current week based on their tasks added on To-Do Page. The chart is only displayed for sign-in users since tasks are only being stored in the Firestone db for sign-in users. The chart can be implemented into other pages as needed.

Closes #145 
Signed in user view:
<img width="598" alt="Screenshot 2025-02-21 at 2 09 30 PM" src="https://github.com/user-attachments/assets/3068f659-fefb-4537-893f-b4a7982ceac9" />

Non-signed in user view:
<img width="598" alt="Screenshot 2025-02-21 at 2 09 36 PM" src="https://github.com/user-attachments/assets/749f770e-f98a-44f7-b0ba-74b34a146e79" />
