### PR TITLE
JL - Temporarily moved metrics charts to home page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2975,6 +2975,7 @@
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
       "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==",
+      "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.15"
       }
@@ -2983,6 +2984,7 @@
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-6.1.15.tgz",
       "integrity": "sha512-U1bce04tYDwkFnuVImJSy2XalYIIQr6YusOWRPM/5ivHcJh67Gm8CIMSWpi3KdRSNKFkqBxLPkfZGBMaOcJYug==",
+      "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.15"
       }
@@ -2991,6 +2993,7 @@
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.15.tgz",
       "integrity": "sha512-L0b9hybS2J4e7lq6G2CD4nqriyLEqOH1tE8iI6JQjAMTVh5JicOo5Mqw+fhU5bJ7hLfMw2K3fksxX3Ul1ssw5w==",
+      "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.15",
         "react": "^16.7.0 || ^17 || ^18 || ^19",
@@ -3001,6 +3004,7 @@
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.15.tgz",
       "integrity": "sha512-61ORr3A148RtxQ2FNG7JKvacyA/TEVZ7z6I+3E9Oeu3dqTf6M928bFcpehRTIK6zIA6Yifs7BeWHgOE9dFnpbw==",
+      "license": "MIT",
       "dependencies": {
         "@fullcalendar/daygrid": "~6.1.15"
       },
@@ -5403,6 +5407,7 @@
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
       "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Navbar from './components/NavBar/Navbar';
+import HomeSidebar from './components/Home/HomeSidebar';
 import Profile from './components/Profile/Profile';
 import CalendarPage from './components/Calendar/CalendarPage';
 import TaskPage from './components/ToDo/TaskPage';
@@ -259,6 +260,7 @@ const App = () => {
           <Route
             path="/"
             element={
+              <>
               <div className="timer-page">
                 {/* Icy overlay if on break */}
                 <div className={`icy-overlay ${onBreak ? 'visible' : ''}`}>
@@ -361,6 +363,8 @@ const App = () => {
                   handleSettingsChange={handleSettingsChange}
                 />
               </div>
+              <HomeSidebar />
+              </>
             }
           />
 

--- a/frontend/src/components/Home/HomeSidebar.css
+++ b/frontend/src/components/Home/HomeSidebar.css
@@ -1,21 +1,27 @@
-.sidebar p {
+.homesidebar p {
     color: var(--accent-background);
     text-align: center;
  }
  
  
- .sidebar h2 {
+ .homesidebar h1 {
     color: var(--faint-text);
     font-size: 1.3rem;
     font-weight: 400;
  }
  
  
- .sidebar {
+ .homesidebar {
     display: flex;
     flex-direction: column;
     justify-content: top;
-    align-items: left;
     height: 93vh;
+    width: 250px; /* Adjust as needed */
+    position: fixed;
+    right: 0;
+    top: 50px;
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+    padding: 20px;
+    background: var(--secondary-accent-background);
  }
  

--- a/frontend/src/components/Home/HomeSidebar.css
+++ b/frontend/src/components/Home/HomeSidebar.css
@@ -1,0 +1,21 @@
+.sidebar p {
+    color: var(--accent-background);
+    text-align: center;
+ }
+ 
+ 
+ .sidebar h2 {
+    color: var(--faint-text);
+    font-size: 1.3rem;
+    font-weight: 400;
+ }
+ 
+ 
+ .sidebar {
+    display: flex;
+    flex-direction: column;
+    justify-content: top;
+    align-items: left;
+    height: 93vh;
+ }
+ 

--- a/frontend/src/components/Home/HomeSidebar.js
+++ b/frontend/src/components/Home/HomeSidebar.js
@@ -1,0 +1,15 @@
+import React from "react";
+import "./HomeSidebar.css";
+import MetricsChart from "../ToDo/MetricsChart.js";
+import TaskCalendarChart from "../ToDo/TaskCalendarChart.js";
+
+
+const Sidebar = () => {
+   return (
+     <div className="sidebar">
+       <h2>Metrics</h2>
+       <TaskCalendarChart />
+     </div>
+   );
+ };
+  export default Sidebar;

--- a/frontend/src/components/Home/HomeSidebar.js
+++ b/frontend/src/components/Home/HomeSidebar.js
@@ -4,12 +4,16 @@ import MetricsChart from "../ToDo/MetricsChart.js";
 import TaskCalendarChart from "../ToDo/TaskCalendarChart.js";
 
 
-const Sidebar = () => {
+const HomeSidebar = () => {
    return (
-     <div className="sidebar">
-       <h2>Metrics</h2>
-       <TaskCalendarChart />
+     <div className="homesidebar">
+        <h1>Metrics</h1>
+       <div>
+            <TaskCalendarChart />
+       </div>
+       <div>
+        <MetricsChart/></div>
      </div>
    );
  };
-  export default Sidebar;
+  export default HomeSidebar;

--- a/frontend/src/components/ToDo/MetricsChart.css
+++ b/frontend/src/components/ToDo/MetricsChart.css
@@ -1,8 +1,11 @@
 .chartContainer {
-    width: 250px;
-    margin-bottom: -5px;
-    margin-top: -150px;
-    color: var(--text-color);  /* Ensure text like legend labels uses theme */
+    width: 220px;
+    color: var(--text-color);
+    display: flex;
+    flex-direction: column;
+    margin-left: 15px;
+    margin-top: 50px;
+  /* Ensure text like legend labels uses theme */
 }
 
 /* CSS Variables for Theming */

--- a/frontend/src/components/ToDo/MetricsChart.js
+++ b/frontend/src/components/ToDo/MetricsChart.js
@@ -83,6 +83,10 @@ const MetricsChart = () => {
       }
     }
   };
+  // **Render nothing if user is not signed in**
+  if (!user) {
+    return;
+  }
 
   return (
     <div className="chartContainer">

--- a/frontend/src/components/ToDo/TaskCalendarChart.js
+++ b/frontend/src/components/ToDo/TaskCalendarChart.js
@@ -85,7 +85,7 @@ const TasksCalendarChart = () => {
 
   // **Render nothing if user is not signed in**
   if (!user) {
-    return <p>Please sign in to view your tasks chart.</p>;
+    return <p>Please sign in to view your task metrics.</p>;
   }
 
   return (

--- a/frontend/src/components/ToDo/TaskCalendarChart.js
+++ b/frontend/src/components/ToDo/TaskCalendarChart.js
@@ -46,7 +46,7 @@ const TasksCalendarChart = () => {
   const tasksPerDay = new Array(7).fill(0); 
 
   // **Filter only tasks that are not completed**
-  const pendingTasks = tasks.filter((task) => task.status !== "Done");
+  const pendingTasks = tasks.filter((task) => task.completed !== true);
 
   // Count pending tasks for each day of the current week
   pendingTasks.forEach((task) => {


### PR DESCRIPTION
Since the Tasks Page and Calendar Page have been redesigned and no longer display the metrics chart, I moved both the Total Tasks chart and the Weekly Tasks Chart to the Home/Timer page. The plan is to eventually move them to the user's Profile Page but since that is not ready, they will be temporarily displayed on the home page. Both charts have been updated to use the new _task_ parameters.
Sign In User View:
<img width="1683" alt="Screenshot 2025-02-25 at 5 06 30 PM" src="https://github.com/user-attachments/assets/45e593d1-e7d0-4201-bcc0-7edd5c73e842" />

Non-signed In User View:
<img width="1683" alt="Screenshot 2025-02-25 at 5 23 42 PM" src="https://github.com/user-attachments/assets/a7fc01e5-1147-4173-a52c-6d5d8a9b5d34" />



- Closes #156 