### PR TITLE
KL - only show ucsb.edu emails

### DIFF
--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -1,6 +1,10 @@
 import { signInWithPopup, signOut, GoogleAuthProvider } from "firebase/auth";
 import { auth, provider } from "./firebase";
 
+provider.setCustomParameters({
+  hd: "ucsb.edu",
+});
+
 provider.addScope("https://www.googleapis.com/auth/calendar");
 
 export const BACKEND_URL =


### PR DESCRIPTION
Since our app only allows for UCSB organization users to login, I disabled the ability to select out of organization emails. this updated ensures that users do not select the wrong email and get an error. 

Image below shows that only ucsb emails are login options
<img width="440" alt="Screenshot 2025-02-28 at 10 50 05 PM" src="https://github.com/user-attachments/assets/8dc693cb-c1cc-498f-a458-6105b331d754" />
- closes #167 