### PR TITLE
KL - tasks now appear on Google Calendar

### DIFF
--- a/backend/src/main/java/com/example/timewise/controller/CalendarController.java
+++ b/backend/src/main/java/com/example/timewise/controller/CalendarController.java
@@ -146,12 +146,14 @@ public class CalendarController {
         eventData.setDescription(taskEventDTO.getDescription());
 
         // Build start and end times based on deadline
-        String startDateTimeStr = taskEventDTO.getDeadline() + "T00:00:00Z";
-        String endDateTimeStr = taskEventDTO.getDeadline() + "T01:00:00Z";
-        logger.debug("Constructed startDateTime: {} and endDateTime: {}", startDateTimeStr, endDateTimeStr);
-
-        EventDateTime start = new EventDateTime().setDateTime(new DateTime(startDateTimeStr));
-        EventDateTime end = new EventDateTime().setDateTime(new DateTime(endDateTimeStr));
+        String startDateTimeStr = taskEventDTO.getDeadline() + "T00:00:00-08:00";
+        String endDateTimeStr = taskEventDTO.getDeadline() + "T01:00:00-08:00";
+        EventDateTime start = new EventDateTime()
+            .setDateTime(new DateTime(startDateTimeStr))
+            .setTimeZone("America/Los_Angeles"); 
+        EventDateTime end = new EventDateTime()
+            .setDateTime(new DateTime(endDateTimeStr))
+            .setTimeZone("America/Los_Angeles");
         eventData.setStart(start);
         eventData.setEnd(end);
 
@@ -169,5 +171,5 @@ public class CalendarController {
         }
 
         return createdEvent;
-    }
+    }   
 }

--- a/backend/src/main/java/com/example/timewise/controller/CalendarController.java
+++ b/backend/src/main/java/com/example/timewise/controller/CalendarController.java
@@ -1,5 +1,8 @@
 package com.example.timewise.controller;
 
+import com.example.timewise.dto.TaskEventDTO;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.util.DateTime;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.http.HttpCredentialsAdapter;
@@ -7,7 +10,11 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.calendar.Calendar;
-import com.google.api.services.calendar.model.*;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.EventDateTime;
+import com.google.api.services.calendar.model.Events;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -19,6 +26,7 @@ import java.util.*;
 @CrossOrigin(origins = { "http://localhost:3000", "https://pj-timewise.netlify.app" })
 public class CalendarController {
 
+    private static final Logger logger = LoggerFactory.getLogger(CalendarController.class);
     private static final String APPLICATION_NAME = "Timewise Calendar";
     private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
@@ -28,8 +36,11 @@ public class CalendarController {
     private Calendar initializeCalendarService(String authHeader) throws IOException, GeneralSecurityException {
         String oauthToken = authHeader.replace("Bearer ", "").trim();
         if (oauthToken == null || oauthToken.isEmpty()) {
+            logger.error("No OAuth token provided in Authorization header.");
             throw new RuntimeException("No OAuth token provided in Authorization header.");
         }
+        logger.debug("OAuth token found. Initializing Calendar service.");
+
         // Set expiration time far in the future (1 year)
         Date expirationTime = new Date(System.currentTimeMillis() + 31536000000L);
         AccessToken accessToken = new AccessToken(oauthToken, expirationTime);
@@ -40,30 +51,37 @@ public class CalendarController {
 
         HttpCredentialsAdapter requestInitializer = new HttpCredentialsAdapter(credentials);
 
-        return new Calendar.Builder(new NetHttpTransport(), JSON_FACTORY, requestInitializer)
+        Calendar calendarService = new Calendar.Builder(new NetHttpTransport(), JSON_FACTORY, requestInitializer)
                 .setApplicationName(APPLICATION_NAME)
                 .build();
+        logger.debug("Calendar service initialized successfully.");
+        return calendarService;
     }
 
     @GetMapping("/events")
     public List<Map<String, String>> getUserCalendarEvents(@RequestHeader("Authorization") String authHeader)
             throws IOException, GeneralSecurityException {
 
+        logger.debug("Fetching Google Calendar events.");
         Calendar service = initializeCalendarService(authHeader);
 
         List<Event> allEvents = new ArrayList<>();
         String pageToken = null;
         do {
-            Events eventsPage = service.events().list("primary")
+            logger.debug("Fetching events with page token: {}", pageToken);
+            Calendar.Events.List request = service.events().list("primary")
                     .setOrderBy("startTime")
                     .setSingleEvents(true)
-                    .setMaxResults(250)
-                    .setPageToken(pageToken)
-                    .execute();
+                    .setMaxResults(250);
+            if (pageToken != null) {
+                request.setPageToken(pageToken);
+            }
+            Events eventsPage = request.execute();
             allEvents.addAll(eventsPage.getItems());
             pageToken = eventsPage.getNextPageToken();
         } while (pageToken != null);
 
+        logger.info("Total events retrieved: {}", allEvents.size());
         List<Map<String, String>> userEvents = new ArrayList<>();
         for (Event event : allEvents) {
             // Extract start time
@@ -91,21 +109,65 @@ public class CalendarController {
             }
             userEvents.add(eventData);
         }
+        logger.debug("Returning {} events to client.", userEvents.size());
         return userEvents;
     }
 
     /**
-     * Creates a new event (task) in the user's Google Calendar.
-     * Expects the event data in the request body.
+     * Creates a new event (task) in the user's Google Calendar based on TaskBoard
+     * data.
+     * Expects the event data in the request body as a TaskEventDTO.
+     * It uses the "deadline" field (in "YYYY-MM-DD" format) to force a start time
+     * of 00:00 and an end time of 01:00.
      */
     @PostMapping("/tasks")
-    public Event createCalendarTask(@RequestHeader("Authorization") String authHeader, @RequestBody Event eventData)
+    public Event createCalendarTask(@RequestHeader("Authorization") String authHeader,
+            @RequestBody TaskEventDTO taskEventDTO)
             throws IOException, GeneralSecurityException {
+
+        logger.debug("Received request to create a new calendar task. TaskEventDTO: {}", taskEventDTO);
+
+        // Validate that deadline and task title are provided
+        if (taskEventDTO.getDeadline() == null || taskEventDTO.getDeadline().isEmpty()) {
+            logger.error("Missing deadline in TaskEventDTO");
+            throw new IllegalArgumentException("Missing deadline");
+        }
+        if (taskEventDTO.getText() == null || taskEventDTO.getText().isEmpty()) {
+            logger.error("Missing task title in TaskEventDTO");
+            throw new IllegalArgumentException("Missing task title");
+        }
 
         Calendar service = initializeCalendarService(authHeader);
 
-        // Insert the new event into the primary calendar.
-        Event createdEvent = service.events().insert("primary", eventData).execute();
+        // Build a Google Calendar Event using the provided deadline
+        Event eventData = new Event();
+        // Use the text property as the event title
+        eventData.setSummary(taskEventDTO.getText());
+        eventData.setDescription(taskEventDTO.getDescription());
+
+        // Build start and end times based on deadline
+        String startDateTimeStr = taskEventDTO.getDeadline() + "T00:00:00Z";
+        String endDateTimeStr = taskEventDTO.getDeadline() + "T01:00:00Z";
+        logger.debug("Constructed startDateTime: {} and endDateTime: {}", startDateTimeStr, endDateTimeStr);
+
+        EventDateTime start = new EventDateTime().setDateTime(new DateTime(startDateTimeStr));
+        EventDateTime end = new EventDateTime().setDateTime(new DateTime(endDateTimeStr));
+        eventData.setStart(start);
+        eventData.setEnd(end);
+
+        Event createdEvent = null;
+        try {
+            logger.debug("Inserting event into Google Calendar...");
+            createdEvent = service.events().insert("primary", eventData).execute();
+            logger.info("Event created successfully with ID: {}", createdEvent.getId());
+        } catch (GoogleJsonResponseException e) {
+            logger.error("Google API error: {}", e.getDetails(), e);
+            throw e;
+        } catch (IOException ex) {
+            logger.error("Error occurred while inserting event: {}", ex.getMessage(), ex);
+            throw ex;
+        }
+
         return createdEvent;
     }
 }

--- a/backend/src/main/java/com/example/timewise/dto/EventDTO.java
+++ b/backend/src/main/java/com/example/timewise/dto/EventDTO.java
@@ -1,0 +1,44 @@
+package com.example.timewise.dto;
+
+import java.util.Map;
+
+public class EventDTO {
+    private String summary;
+    private String description;
+    private Map<String, String> start;
+    private Map<String, String> end;
+
+    // Getters and Setters
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, String> getStart() {
+        return start;
+    }
+
+    public void setStart(Map<String, String> start) {
+        this.start = start;
+    }
+
+    public Map<String, String> getEnd() {
+        return end;
+    }
+
+    public void setEnd(Map<String, String> end) {
+        this.end = end;
+    }
+}

--- a/backend/src/main/java/com/example/timewise/dto/TaskEventDTO.java
+++ b/backend/src/main/java/com/example/timewise/dto/TaskEventDTO.java
@@ -1,0 +1,26 @@
+package com.example.timewise.dto;
+
+public class TaskEventDTO {
+    private String text; // This will be used for the task title.
+    private String description;
+    private String deadline; // in "YYYY-MM-DD" format
+
+    public String getText() {
+        return text;
+    }
+    public void setText(String text) {
+        this.text = text;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    public String getDeadline() {
+        return deadline;
+    }
+    public void setDeadline(String deadline) {
+        this.deadline = deadline;
+    }
+}

--- a/frontend/src/components/Calendar/CalendarEmbed.js
+++ b/frontend/src/components/Calendar/CalendarEmbed.js
@@ -4,16 +4,11 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import listPlugin from "@fullcalendar/list";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import { fetchEvents as fetchGoogleCalendarEvents } from "../../services/CalendarService";
-import { db, auth } from "../../firebase";
-import { collection, getDocs } from "firebase/firestore";
-import { onAuthStateChanged } from "firebase/auth";
 import "./CalendarEmbed.css";
 import EventDetailsModal from "./EventDetailsModal";
 
 const CalendarEmbed = () => {
   const [googleEvents, setGoogleEvents] = useState([]);
-  const [firestoreEvents, setFirestoreEvents] = useState([]);
-  const [combinedEvents, setCombinedEvents] = useState([]);
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -54,75 +49,10 @@ const CalendarEmbed = () => {
     }
   };
 
-  // Fetch tasks from Firestore and convert them into calendar events.
-  // Here we use the "deadline" field for the event's start time.
-  // The end date is set to start date + 1 hour.
-  const loadFirestoreEvents = async (uid) => {
-    try {
-      const listsSnapshot = await getDocs(collection(db, `users/${uid}/lists`));
-      const listsData = listsSnapshot.docs.map((docSnap) => docSnap.id);
-
-      let allTasks = [];
-      for (const listId of listsData) {
-        const tasksSnapshot = await getDocs(
-          collection(db, `users/${uid}/lists/${listId}/tasks`)
-        );
-        const tasksForList = tasksSnapshot.docs.map((docSnap) => ({
-          id: docSnap.id,
-          listId,
-          ...docSnap.data(),
-        }));
-        allTasks = allTasks.concat(tasksForList);
-      }
-
-      const eventsData = allTasks
-        .filter((task) => task.deadline)
-        .map((task) => {
-          const startDate = new Date(task.deadline);
-          const isoStart = startDate.toISOString();
-          const endDate = new Date(startDate);
-          endDate.setHours(endDate.getHours() + 1);
-          const isoEnd = endDate.toISOString();
-          return {
-            id: task.id,
-            title: task.text || "No Title",
-            start: isoStart,
-            end: isoEnd,
-            allDay: false,
-            description: task.description || "",
-          };
-        });
-
-      setFirestoreEvents(eventsData);
-    } catch (error) {
-      console.error("Error fetching Firestore tasks:", error);
-    }
-  };
-
-  // Listen to auth state changes to fetch Firestore tasks.
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      if (currentUser) {
-        loadFirestoreEvents(currentUser.uid);
-      } else {
-        setFirestoreEvents([]);
-      }
-    });
-    return () => unsubscribe();
-  }, []);
-
   // Load Google Calendar events on mount.
   useEffect(() => {
     loadGoogleEvents();
   }, []);
-
-  // Combine events from both sources whenever they change.
-  useEffect(() => {
-    const combined = [...googleEvents, ...firestoreEvents].sort(
-      (a, b) => new Date(a.start) - new Date(b.start)
-    );
-    setCombinedEvents(combined);
-  }, [googleEvents, firestoreEvents]);
 
   const handleEventClick = (clickInfo) => {
     setSelectedEvent({
@@ -142,7 +72,7 @@ const CalendarEmbed = () => {
         eventClick={handleEventClick}
         initialView="dayGridMonth"
         initialDate={new Date()}
-        events={combinedEvents}
+        events={googleEvents}
         headerToolbar={{
           left: "prev,next",
           center: "title",

--- a/frontend/src/components/Calendar/CalendarEmbed.js
+++ b/frontend/src/components/Calendar/CalendarEmbed.js
@@ -40,7 +40,6 @@ const CalendarEmbed = () => {
             title: event.summary || event.title || "No Title",
             start,
             allDay: isAllDay,
-            description: event.description || "",
           };
           // For timed events, include the end property if available.
           if (!isAllDay && end && end.trim() !== "") {

--- a/frontend/src/components/ToDo/TaskList.js
+++ b/frontend/src/components/ToDo/TaskList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import TaskToggle from "./TaskLabelToggle";
 import "./TaskList.css";
 
@@ -108,7 +108,7 @@ const TaskList = ({ uid, selectedView }) => {
   const [timeDropdownTaskId, setTimeDropdownTaskId] = useState(null);
   const [hoveredLabelId, setHoveredLabelId] = useState(null);
   const [labelOptionsOpen, setLabelOptionsOpen] = useState(null);
-
+  const syncInProgressRef = useRef({});
   useEffect(() => {
     if (!uid || !selectedView?.id) return;
     const docRef = doc(db, `users/${uid}/lists`, selectedView.id);
@@ -135,10 +135,13 @@ const TaskList = ({ uid, selectedView }) => {
       return;
     }
     try {
-      const taskDocRef = doc(db, `users/${uid}/lists/${selectedView.id.toString()}/tasks`, id.toString());
+      const taskDocRef = doc(
+        db,
+        `users/${uid}/lists/${selectedView.id.toString()}/tasks`,
+        id.toString()
+      );
       await updateDoc(taskDocRef, data);
-    }
-    catch (error) {
+    } catch (error) {
       console.error("Error updating task:", error);
     }
   };
@@ -178,7 +181,6 @@ const TaskList = ({ uid, selectedView }) => {
       isEditingDeadline: false,
     };
     try {
-      console.log("Adding task:", customID, " To list:", selectedView.id.toString());
       const taskDocRef = doc(db, `users/${uid}/lists/${selectedView.id.toString()}/tasks`, customID);
       await setDoc(taskDocRef, newTask);
     } catch (error) {
@@ -278,9 +280,9 @@ const TaskList = ({ uid, selectedView }) => {
     setTasks((prev) =>
       prev.map((task) => {
         if (task.id === id) {
+          // Only update local state; remove Firestore update here.
           const dateObj = new Date(newDate + "T00:00:00");
           const iso = dateObj.toISOString();
-          updateTaskDoc(id.toString(), { deadline: iso });
           return { ...task, deadline: iso };
         }
         return task;
@@ -288,32 +290,62 @@ const TaskList = ({ uid, selectedView }) => {
     );
   };
 
+  const syncTaskToGoogleCalendar = (task) => {
+    if (!task.deadline) return;
+
+    // Format the deadline as "YYYY-MM-DD"
+    const deadlineDate = new Date(task.deadline);
+    const yyyy = deadlineDate.getFullYear();
+    const mm = (deadlineDate.getMonth() + 1).toString().padStart(2, "0");
+    const dd = deadlineDate.getDate().toString().padStart(2, "0");
+    const deadlineStr = `${yyyy}-${mm}-${dd}`;
+
+    // If the task is already synced for this deadline, don't sync again.
+    if (task.lastSyncedDeadline === deadlineStr) {
+      console.log("Task already synced for this deadline:", deadlineStr);
+      return;
+    }
+
+    // If a sync for this task is already in progress, skip further calls.
+    if (syncInProgressRef.current[task.id]) {
+      return;
+    }
+
+    // Mark this task as currently syncing.
+    syncInProgressRef.current[task.id] = true;
+    updateTaskDoc(task.id, { isSyncingCalendar: true });
+
+    addDeadlineTaskToCalendar({
+      text: task.text || "Untitled Task",
+      deadline: deadlineStr,
+      description: task.description || ""
+    })
+      .then((response) => {
+        // Mark the task as synced and clear the syncing flag.
+        updateTaskDoc(task.id, {
+          lastSyncedDeadline: deadlineStr,
+          isSyncingCalendar: false,
+          isEditingDeadline: false
+        });
+        delete syncInProgressRef.current[task.id];
+      })
+      .catch((err) => {
+        console.error("Calendar sync error:", err);
+        // Clear the syncing flag on error.
+        updateTaskDoc(task.id, { isSyncingCalendar: false });
+        delete syncInProgressRef.current[task.id];
+      });
+  };
+
   const finishEditingDeadline = (id) => {
-    console.log("finishEditingDeadline called for task id:", id);
     setTasks((prev) =>
       prev.map((task) => {
         if (task.id !== id) return task;
-        let updated = { ...task, isEditingDeadline: false };
-        if (updated.deadline) {
-          // Convert ISO deadline to "YYYY-MM-DD" format
-          const deadlineDate = new Date(updated.deadline);
-          const yyyy = deadlineDate.getFullYear();
-          const mm = (deadlineDate.getMonth() + 1).toString().padStart(2, "0");
-          const dd = deadlineDate.getDate().toString().padStart(2, "0");
-          const deadlineStr = `${yyyy}-${mm}-${dd}`;
-          // Sync to Google Calendar using the task's text (stored in 'text') as the event title.
-          addDeadlineTaskToCalendar({
-            text: updated.text || "Untitled Task",
-            deadline: deadlineStr,
-            description: ""
-          })
-            .then((response) => console.log("Synced to Google Calendar:", response))
-            .catch((err) => console.error("Calendar sync error:", err));
-          if (!updated.timeValue) {
-            setTimeDropdownTaskId(updated.id);
-          }
-        }
-        updateTaskDoc(id.toString(), { isEditingDeadline: false });
+        const updated = { ...task, isEditingDeadline: false };
+        // Always update Firestore with the new deadline and editing state.
+        updateTaskDoc(task.id, { deadline: updated.deadline, isEditingDeadline: false });
+        // Now call our dedicated sync function
+        syncTaskToGoogleCalendar(updated);
         return updated;
       })
     );
@@ -541,7 +573,7 @@ const TaskList = ({ uid, selectedView }) => {
               {task.text || "Untitled Task"}
             </span>
           )}
-  
+
           {task.isEditingDeadline ? (
             <div className="deadline-edit-container">
               <input
@@ -558,8 +590,10 @@ const TaskList = ({ uid, selectedView }) => {
               </button>
             </div>
           ) : (
-            <div className={`deadline-btn ${deadlineClass}`} 
-                 onClick={() => startEditingDeadline(task.id)}>
+            <div
+              className={`deadline-btn ${deadlineClass}`}
+              onClick={() => startEditingDeadline(task.id)}
+            >
               {task.deadline ? formatDeadline(task.deadline) : "Provide Deadline"}
             </div>
           )}

--- a/frontend/src/services/CalendarService.js
+++ b/frontend/src/services/CalendarService.js
@@ -1,7 +1,9 @@
 import axios from "axios";
 import { BACKEND_URL } from "../auth";
 
-// Fetch events from Google Calendar.
+/**
+ * Fetch events from Google Calendar.
+ */
 export const fetchEvents = async () => {
   const token = localStorage.getItem("googleToken");
   if (!token) {
@@ -19,137 +21,12 @@ export const fetchEvents = async () => {
   }
 };
 
-// Helper to compute the next day in YYYY-MM-DD format (all‑day events require the end date to be exclusive)
-const getNextDay = (dateStr) => {
-  const date = new Date(dateStr);
-  date.setDate(date.getDate() + 1);
-  const year = date.getFullYear();
-  const month = ("0" + (date.getMonth() + 1)).slice(-2);
-  const day = ("0" + date.getDate()).slice(-2);
-  return `${year}-${month}-${day}`;
-};
-
 /**
- * Creates an all‑day event in the user's Google Calendar for the given task.
- * Expects taskData to have the following properties:
- * - title: The task title.
- * - description: (Optional) A description of the task.
- * - date: The date for the task in "YYYY-MM-DD" format.
- */
-export const addTaskToCalendar = async (taskData) => {
-  const token = localStorage.getItem("googleToken");
-  if (!token) {
-    throw new Error("No Google token found in localStorage");
-  }
-
-  // For all‑day events, the 'end' date is exclusive, so we set it to the next day.
-  const eventData = {
-    summary: `Task: ${taskData.title}`,
-    description: taskData.description || "",
-    start: {
-      date: taskData.date, // e.g., "2025-03-01"
-    },
-    end: {
-      date: getNextDay(taskData.date), // e.g., "2025-03-02"
-    },
-  };
-
-  try {
-    const response = await axios.post(
-      `${BACKEND_URL}/api/calendar/tasks`,
-      eventData,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    return response.data;
-  } catch (error) {
-    console.error("Error adding task to calendar:", error);
-    throw error;
-  }
-};
-
-/**
- * Creates a timed event in the user's Google Calendar for the given task.
- * Expects taskData to have the following properties:
- * - title: The task title.
- * - description: (Optional) A description of the task.
- * - dateTime: The date for the event in ISO format. The time portion will be ignored and replaced.
- *
- * This function forces the event to start at 00:00 and end at 01:00 on the given day.
- */
-export const addTimedTaskToCalendar = async (taskData) => {
-  const token = localStorage.getItem("googleToken");
-  if (!token) {
-    throw new Error("No Google token found in localStorage");
-  }
-
-  // Create a date object from the provided dateTime, then force start time to 00:00
-  const providedDate = new Date(taskData.dateTime);
-  providedDate.setHours(0, 0, 0, 0);
-  const startISO = providedDate.toISOString();
-
-  // Set the end time to exactly one hour later (01:00)
-  const endDate = new Date(providedDate);
-  endDate.setHours(endDate.getHours() + 1);
-  const endISO = endDate.toISOString();
-
-  const eventData = {
-    summary: `Task: ${taskData.title}`,
-    description: taskData.description || "",
-    start: {
-      dateTime: startISO, // forced to 00:00 of the day
-    },
-    end: {
-      dateTime: endISO, // forced to 01:00 of the day
-    },
-  };
-
-  try {
-    const response = await axios.post(
-      `${BACKEND_URL}/api/calendar/tasks`,
-      eventData,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
-    return response.data;
-  } catch (error) {
-    console.error("Error adding timed task to calendar:", error);
-    throw error;
-  }
-};
-
-/**
- * Helper function to build an event object for a deadline task.
- * Expects taskData.deadline in "YYYY-MM-DD" format and taskData.text as the task title.
- * This will force the event to start at 00:00 and end at 01:00 on the given day.
- */
-const buildTimedEventFromDeadline = (taskData) => {
-  // Construct start and end ISO strings for the given date.
-  const startDateTime = `${taskData.deadline}T00:00:00Z`;
-  const endDateTime = `${taskData.deadline}T01:00:00Z`;
-  return {
-    summary: `Task: ${taskData.text}`, // using taskData.text now
-    description: taskData.description || "",
-    start: {
-      dateTime: startDateTime,
-    },
-    end: {
-      dateTime: endDateTime,
-    },
-  };
-};
-
-/**
- * Creates a timed event in the user's Google Calendar for the given task.
+ * Creates a timed event in the user's Google Calendar for a deadline task.
  * Expects taskData to have the following properties:
  * - text: The task title.
  * - deadline: The date for the task in "YYYY-MM-DD" format.
+ * - description: (Optional) A description of the task.
  *
  * This function forces the event to start at 00:00 and end at 01:00 on the given day.
  */

--- a/frontend/src/services/CalendarService.js
+++ b/frontend/src/services/CalendarService.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { BACKEND_URL } from "../auth";
 
+// Fetch events from Google Calendar.
 export const fetchEvents = async () => {
   const token = localStorage.getItem("googleToken");
   if (!token) {
@@ -23,8 +24,8 @@ const getNextDay = (dateStr) => {
   const date = new Date(dateStr);
   date.setDate(date.getDate() + 1);
   const year = date.getFullYear();
-  const month = ('0' + (date.getMonth() + 1)).slice(-2);
-  const day = ('0' + date.getDate()).slice(-2);
+  const month = ("0" + (date.getMonth() + 1)).slice(-2);
+  const day = ("0" + date.getDate()).slice(-2);
   return `${year}-${month}-${day}`;
 };
 
@@ -75,7 +76,9 @@ export const addTaskToCalendar = async (taskData) => {
  * Expects taskData to have the following properties:
  * - title: The task title.
  * - description: (Optional) A description of the task.
- * - dateTime: The start date/time for the task in ISO format (e.g., "2025-03-01T09:00:00-08:00").
+ * - dateTime: The date for the event in ISO format. The time portion will be ignored and replaced.
+ *
+ * This function forces the event to start at 00:00 and end at 01:00 on the given day.
  */
 export const addTimedTaskToCalendar = async (taskData) => {
   const token = localStorage.getItem("googleToken");
@@ -83,11 +86,24 @@ export const addTimedTaskToCalendar = async (taskData) => {
     throw new Error("No Google token found in localStorage");
   }
 
+  // Create a date object from the provided dateTime, then force start time to 00:00
+  const providedDate = new Date(taskData.dateTime);
+  providedDate.setHours(0, 0, 0, 0);
+  const startISO = providedDate.toISOString();
+
+  // Set the end time to exactly one hour later (01:00)
+  const endDate = new Date(providedDate);
+  endDate.setHours(endDate.getHours() + 1);
+  const endISO = endDate.toISOString();
+
   const eventData = {
     summary: `Task: ${taskData.title}`,
     description: taskData.description || "",
     start: {
-      dateTime: taskData.dateTime, // e.g., "2025-03-01T09:00:00-08:00"
+      dateTime: startISO, // forced to 00:00 of the day
+    },
+    end: {
+      dateTime: endISO, // forced to 01:00 of the day
     },
   };
 
@@ -103,7 +119,59 @@ export const addTimedTaskToCalendar = async (taskData) => {
     );
     return response.data;
   } catch (error) {
-    console.error("Error adding task to calendar:", error);
+    console.error("Error adding timed task to calendar:", error);
+    throw error;
+  }
+};
+
+/**
+ * Helper function to build an event object for a deadline task.
+ * Expects taskData.deadline in "YYYY-MM-DD" format and taskData.text as the task title.
+ * This will force the event to start at 00:00 and end at 01:00 on the given day.
+ */
+const buildTimedEventFromDeadline = (taskData) => {
+  // Construct start and end ISO strings for the given date.
+  const startDateTime = `${taskData.deadline}T00:00:00Z`;
+  const endDateTime = `${taskData.deadline}T01:00:00Z`;
+  return {
+    summary: `Task: ${taskData.text}`, // using taskData.text now
+    description: taskData.description || "",
+    start: {
+      dateTime: startDateTime,
+    },
+    end: {
+      dateTime: endDateTime,
+    },
+  };
+};
+
+/**
+ * Creates a timed event in the user's Google Calendar for the given task.
+ * Expects taskData to have the following properties:
+ * - text: The task title.
+ * - deadline: The date for the task in "YYYY-MM-DD" format.
+ *
+ * This function forces the event to start at 00:00 and end at 01:00 on the given day.
+ */
+export const addDeadlineTaskToCalendar = async (taskData) => {
+  const token = localStorage.getItem("googleToken");
+  if (!token) {
+    throw new Error("No Google token found in localStorage");
+  }
+  try {
+    const response = await axios.post(
+      `${BACKEND_URL}/api/calendar/tasks`,
+      taskData, // send payload directly
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error adding deadline task to calendar:", error);
     throw error;
   }
 };


### PR DESCRIPTION
- closes #199 
Updated logic for the Calendar page to not show Firestore data from tasks, now it is completely just a synch from the user's google calendar. Tasks added from the Tasks page will now appear on google calendar. Everything works except DELETE because it was buggy when deleting from google calendar since it did not update on Firestore that it was deleted, so that feature is not included in this PR
- will be working on getting delete to work 