### PR TITLE
KL - Fixed issue with Backend Going to Sleep

### DIFF
--- a/.github/workflows/keep-awake.yml
+++ b/.github/workflows/keep-awake.yml
@@ -2,7 +2,7 @@ name: Keep Render Service Awake
 
 on:
   schedule:
-    - cron: "*/14 * * * *"  # Runs every 5 minutes
+    - cron: "*/14 * * * *"  # Runs every 14 minutes (server sleeps at 15 min)
   workflow_dispatch:  # Allows you to manually trigger the workflow
 
 jobs:

--- a/.github/workflows/keep-awake.yml
+++ b/.github/workflows/keep-awake.yml
@@ -1,0 +1,15 @@
+name: Keep Render Service Awake
+
+on:
+  schedule:
+    - cron: "*/14 * * * *"  # Runs every 5 minutes
+  workflow_dispatch:  # Allows you to manually trigger the workflow
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send HTTP request to keep service awake
+        run: |
+          echo "Pinging the Render endpoint..."
+          curl -I https://pj08-studytimer.onrender.com


### PR DESCRIPTION
- closes #208 
I fixed this issue by adding a gitHub workflow called keep-wake that pings Render every 14 min (it goes to sleep at 15 min). This way right before the server sleeps, we ping it to trick it to stay awake. This is a work-around with Render's Free Tier limitations