### PR TITLE
CZ - Fixed calendar component scroll bug

### DIFF
--- a/frontend/src/components/Calendar/CalendarEmbed.css
+++ b/frontend/src/components/Calendar/CalendarEmbed.css
@@ -24,8 +24,14 @@
   font-family: 'Google Sans', Roboto, Arial, sans-serif;
   font-size: 16px;
   border-bottom: 1px solid #dadce0;
-  postion: relative;
+  position: relative;
+  width: 100%;
   display: flex;
+}
+
+.fc .fc-scrollgrid .fc-scrollgrid-liquid {
+  height: 100%;
+  overflow: auto;
 }
 
 .fc .fc-toolbar-title {
@@ -50,13 +56,13 @@
 }
 
 .fc-daygrid-day-frame {
-  height: 120px;   
+  height: 1rem;   
   width: 100%;
   overflow: hidden;
 }
 
 .fc-daygrid-day-events {
-  max-height: 80px; 
+  max-height: 0.8rem; 
   width: 100%;
   overflow: hidden;
 }

--- a/frontend/src/components/Calendar/CalendarPage.css
+++ b/frontend/src/components/Calendar/CalendarPage.css
@@ -2,7 +2,7 @@
 .calendar-page {
     display: flex;
     flex-direction: column;
-    height: 90vh;       /* not full viewport height so there is only one scrollbar*/
+    height: 92vh;       /* not full viewport height so there is only one scrollbar*/
     overflow: hidden;    /* Prevent nested scrollbars */
     background-color: var(--secondary-background);
   }  
@@ -25,5 +25,5 @@
     justify-content: center;
     align-items: center;
     width: 100%;
-    height: 100%;
+    height: 90vh;
 }


### PR DESCRIPTION
Made it so the entire Calendar component shows up on the page, or users can scroll to see the very last week.

<img width="1440" alt="Screenshot 2025-03-10 at 3 04 23 PM" src="https://github.com/user-attachments/assets/b4eb5bfd-cf89-4211-97a0-a936f741699c" />
