### PR TITLE
KL - added loading screen while calendar events fetch

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,6 +10,13 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups" />
     <title>timewise</title>
+    <style>
+      html, body {
+        background-color: #f0f0f0;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/CalendarContext.js
+++ b/frontend/src/CalendarContext.js
@@ -1,62 +1,62 @@
-import { createContext, useState, useEffect, useContext } from "react";
-import { fetchEvents } from "../src/services/CalendarService.js"
+import { createContext, useState, useEffect, useContext, useCallback } from "react";
+import { fetchEvents } from "../src/services/CalendarService.js";
 
 const CalendarContext = createContext();
 
 export const CalendarProvider = ({ children }) => {
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [hasLoaded, setHasLoaded] = useState(false); // Track if events have already been fetched
+
+  const loadEvents = useCallback(async () => {
+    if (hasLoaded) return; // Prevent re-triggering loading screen when switching tabs
+
+    setLoading(true); // Show loading only on first fetch
+    try {
+      const data = await fetchEvents();
+      const transformed = Object.values(data)
+        .map((event, index) => {
+          const start =
+            typeof event.start === "string"
+              ? event.start
+              : event.start?.dateTime || event.start?.date || "";
+          const end =
+            event.end
+              ? typeof event.end === "string"
+                ? event.end
+                : event.end?.dateTime || event.end?.date || ""
+              : "";
+          const isAllDay = !start.includes("T");
+
+          return {
+            id: event.id || `google-${index}`,
+            title: event.summary || event.title || "No Title",
+            start,
+            end: isAllDay ? null : end,
+            allDay: isAllDay,
+          };
+        })
+        .filter((event) => event.start.trim() !== "");
+
+      setEvents(transformed);
+      setHasLoaded(true); // Mark that events have been fetched
+    } catch (error) {
+      console.error("Error fetching Google Calendar events:", error);
+    } finally {
+      setTimeout(() => {
+        setLoading(false);
+      }, 500);
+    }
+  }, [hasLoaded]);
 
   useEffect(() => {
-    const loadEvents = async () => {
-      try {
-        const data = await fetchEvents();
-        const transformed = Object.values(data)
-          .map((event, index) => {
-            const start =
-              typeof event.start === "string"
-                ? event.start
-                : event.start?.dateTime || event.start?.date || "";
-            const end =
-              event.end
-                ? typeof event.end === "string"
-                  ? event.end
-                  : event.end?.dateTime || event.end?.date || ""
-                : "";
-            const isAllDay = !start.includes("T");
-
-            const eventObj = {
-              id: event.id || `google-${index}`,
-              title: event.summary || event.title || "No Title",
-              start,
-              allDay: isAllDay,
-            };
-
-            if (!isAllDay && end.trim() !== "") {
-              eventObj.end = end;
-            }
-
-            return eventObj;
-          })
-          .filter((event) => event.start.trim() !== "");
-
-        setEvents(transformed);
-      } catch (error) {
-        console.error("Error fetching Google Calendar events:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     loadEvents();
-
-    // Optional: Poll every 30 seconds for updates
     const interval = setInterval(loadEvents, 30000);
     return () => clearInterval(interval);
-  }, []);
+  }, [loadEvents]);
 
   return (
-    <CalendarContext.Provider value={{ events, setEvents, loading }}>
+    <CalendarContext.Provider value={{ events, setEvents, loading, loadEvents, hasLoaded }}>
       {children}
     </CalendarContext.Provider>
   );

--- a/frontend/src/ThemeStyles.css
+++ b/frontend/src/ThemeStyles.css
@@ -52,6 +52,7 @@
     --calendar-day-border: #dadce0;
     --calendar-today-bg: #e8eaed;
     --calendar-today-text: #202124;
+    --calendar-loading-bg: rgba(255, 255, 255, 0.6);
 }
 
 [data-theme="light"] {
@@ -102,6 +103,7 @@
     --calendar-day-border: #dadce0;
     --calendar-today-bg: #e8eaed;
     --calendar-today-text: #202124;
+    --calendar-loading-bg: rgba(255, 255, 255, 0.6);
 }
 
 [data-theme="forest"] {
@@ -152,6 +154,7 @@
     --calendar-day-border: #d3e8d1;
     --calendar-today-bg: #cce4cc;
     --calendar-today-text: #2d4d3a;
+    --calendar-loading-bg: rgba(242, 249, 241, 0.6);
 }
 
 body {

--- a/frontend/src/components/Calendar/CalendarEmbed.css
+++ b/frontend/src/components/Calendar/CalendarEmbed.css
@@ -1,3 +1,10 @@
+html, body {
+  background: var(--calendar-bg);
+  margin: 0;
+  padding: 0;
+  transition: none;
+}
+
 .calendar-wrapper {
   display: flex;
   flex-direction: column;
@@ -8,6 +15,42 @@
   height: 100vh;
   padding: 0;
   box-sizing: border-box;
+}
+
+.loading-overlay {
+  position: fixed;
+  top: 70px;
+  left: 0;
+  width: 100vw;
+  height: calc(100vh - 70px);
+  background: var(--calendar-loading-bg);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  z-index: 2000; 
+  transition: opacity 0.3s ease-in-out;
+}
+
+.loading-overlay.hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.loading-spinner {
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(0, 0, 0, 0.2);
+  border-top: 5px solid var(--calendar-button-bg);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
 .fc {
@@ -87,7 +130,5 @@
 }
 
 .fc-popover .fc-popover-body {
-  background-color: var(--calendar-bg); 
+  background-color: var(--calendar-bg, #f0f0f0); 
 }
-
-


### PR DESCRIPTION
Previously, there was a 3-5 second delay before calendar events would populate. This PR addresses this issue by adding a loading screen for the first time clicking on calendar page and when refreshing. 