### PR TITLE
KL - calendar auto fetch newly added tasks

### DIFF
--- a/frontend/src/CalendarContext.js
+++ b/frontend/src/CalendarContext.js
@@ -6,48 +6,53 @@ const CalendarContext = createContext();
 export const CalendarProvider = ({ children }) => {
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [hasLoaded, setHasLoaded] = useState(false); // Track if events have already been fetched
+  const [hasLoaded, setHasLoaded] = useState(false);
 
-  const loadEvents = useCallback(async () => {
-    if (hasLoaded) return; // Prevent re-triggering loading screen when switching tabs
-
-    setLoading(true); // Show loading only on first fetch
-    try {
-      const data = await fetchEvents();
-      const transformed = Object.values(data)
-        .map((event, index) => {
-          const start =
-            typeof event.start === "string"
-              ? event.start
-              : event.start?.dateTime || event.start?.date || "";
-          const end =
-            event.end
-              ? typeof event.end === "string"
-                ? event.end
-                : event.end?.dateTime || event.end?.date || ""
-              : "";
-          const isAllDay = !start.includes("T");
-
-          return {
-            id: event.id || `google-${index}`,
-            title: event.summary || event.title || "No Title",
-            start,
-            end: isAllDay ? null : end,
-            allDay: isAllDay,
-          };
-        })
-        .filter((event) => event.start.trim() !== "");
-
-      setEvents(transformed);
-      setHasLoaded(true); // Mark that events have been fetched
-    } catch (error) {
-      console.error("Error fetching Google Calendar events:", error);
-    } finally {
-      setTimeout(() => {
-        setLoading(false);
-      }, 500);
-    }
-  }, [hasLoaded]);
+  const loadEvents = useCallback(
+    async (forceLoading = false) => {
+      if (forceLoading || !hasLoaded) {
+        setLoading(true);
+      }
+      try {
+        const data = await fetchEvents();
+        const transformed = Object.values(data)
+          .map((event, index) => {
+            const start =
+              typeof event.start === "string"
+                ? event.start
+                : event.start?.dateTime || event.start?.date || "";
+            const end =
+              event.end
+                ? typeof event.end === "string"
+                  ? event.end
+                  : event.end?.dateTime || event.end?.date || ""
+                : "";
+            const isAllDay = !start.includes("T");
+            return {
+              id: event.id || `google-${index}`,
+              title: event.summary || event.title || "No Title",
+              start,
+              end: isAllDay ? null : end,
+              allDay: isAllDay,
+            };
+          })
+          .filter((event) => event.start.trim() !== "");
+        setEvents(transformed);
+        if (!hasLoaded) {
+          setHasLoaded(true);
+        }
+      } catch (error) {
+        console.error("Error fetching Google Calendar events:", error);
+      } finally {
+        if (forceLoading || !hasLoaded) {
+          setTimeout(() => {
+            setLoading(false);
+          }, 500);
+        }
+      }
+    },
+    [hasLoaded]
+  );
 
   useEffect(() => {
     loadEvents();
@@ -55,8 +60,16 @@ export const CalendarProvider = ({ children }) => {
     return () => clearInterval(interval);
   }, [loadEvents]);
 
+  useEffect(() => {
+    const handleFocus = () => {
+      loadEvents();
+    };
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
+  }, [loadEvents]);
+
   return (
-    <CalendarContext.Provider value={{ events, setEvents, loading, loadEvents, hasLoaded }}>
+    <CalendarContext.Provider value={{ events, loading, loadEvents, hasLoaded }}>
       {children}
     </CalendarContext.Provider>
   );


### PR DESCRIPTION
This PR fixes an issue that arose from PR #277 where calendar was updated to only fetch once when user logged in. This caused issues with newly added tasks from Tasks page and when the user switches back to calendar, those tasks are not fetched until a manual refresh. This PR fixes this issue by auto fetching new tasks while keeping old tasks on the page.