### PR TITLE
JL - Fixed background on About page

### DIFF
--- a/frontend/src/components/About/About.css
+++ b/frontend/src/components/About/About.css
@@ -9,7 +9,7 @@
     font-size: 2.4rem;
     font-family: Arial, sans-serif;
     text-align: center;
-    margin-top: 50px;
+    margin-top: 0px;
 }
 
 .about-paragraph {


### PR DESCRIPTION
On dark/pistachio mode, there was a gap between the navigation bar and the about-container which was showing up as whitespace so I fixed the about-container to fill in the color. It should work on all themes now!
- Closes #235 

Before:
<img width="1710" alt="Screenshot 2025-03-14 at 2 03 35 PM" src="https://github.com/user-attachments/assets/5be660d6-0eb5-48a7-ad53-11483e930474" />

After:
<img width="1710" alt="Screenshot 2025-03-14 at 2 03 39 PM" src="https://github.com/user-attachments/assets/e0b019f7-7e0d-4365-90cf-cbcacdfe6bf3" />
